### PR TITLE
Fix External WS Calls

### DIFF
--- a/generic-md2-bundles/md2_runtime/actions/simpleactions/WebServiceCallAction.js
+++ b/generic-md2-bundles/md2_runtime/actions/simpleactions/WebServiceCallAction.js
@@ -66,8 +66,8 @@ function(declare, lang, json, xhr, ct_lang, ct_request, _Action) {
          */
         _loadValuesFromContentProvider: function(obj) {
             for (var k in obj) {
-                if (obj.hasOwnProperty(k) && typeof obj[k] === 'function') {
-                    obj[k] = obj[k]()._platformValue;
+                if (obj.hasOwnProperty(k) && typeof obj[k].value === 'function') {
+                    obj[k].value = obj[k].value()._platformValue;
                 }
             }
         }


### PR DESCRIPTION
modify _loadValuesFromContentProvider to handle artificial key-value objects
